### PR TITLE
Handled attribute macro without parentheses

### DIFF
--- a/src/attr_macro_visitor.rs
+++ b/src/attr_macro_visitor.rs
@@ -39,9 +39,13 @@ impl<F> AttributeMacroVisitor<F> {
             .iter()
             .filter(|attr| *attr.path() == self.macro_path)
             .for_each(|attr| {
-                let attr: MacroAttrs = attr.parse_args().unwrap();
-
-                (*self.macro_fn)(attr.tokens, item.to_token_stream());
+                if let Ok(attr) = attr.parse_args::<MacroAttrs>() {
+                    // processing attribute macro with argument(s) in parentheses
+                    (*self.macro_fn)(attr.tokens, item.to_token_stream())
+                } else {
+                    // processing attribute macro without parentheses (and arguments)
+                    (*self.macro_fn)(TokenStream::new(), item.to_token_stream())
+                };
             })
     }
 }


### PR DESCRIPTION
Instead of calling `.unwrap()` which panicked in our case when the attribute macro didn't have parentheses (which is a common case), we propose to handle the error as shown in this PR.

@tonyfinn
Thanks in advance for considering applying this change.
This will save us a lot of additional maintenance work in [Sylvia](https://github.com/CosmWasm/sylvia).